### PR TITLE
Managing State and  Life Cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Scrumdinger
+
+https://developer.apple.com/tutorials/app-dev-training/managing-state-and-life-cycle#Add-Life-Cycle-Events

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		873C054D27A5876300657BFC /* MeetingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873C054C27A5876300657BFC /* MeetingHeaderView.swift */; };
+		873C054F27A59CAE00657BFC /* ScrumProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873C054E27A59CAE00657BFC /* ScrumProgressViewStyle.swift */; };
 		874A37FE26D11CE200CC8207 /* ScrumdingerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */; };
 		874A380026D11CE200CC8207 /* MeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A37FF26D11CE200CC8207 /* MeetingView.swift */; };
 		874A380226D11CE400CC8207 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 874A380126D11CE400CC8207 /* Assets.xcassets */; };
@@ -22,6 +23,7 @@
 
 /* Begin PBXFileReference section */
 		873C054C27A5876300657BFC /* MeetingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingHeaderView.swift; sourceTree = "<group>"; };
+		873C054E27A59CAE00657BFC /* ScrumProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumProgressViewStyle.swift; sourceTree = "<group>"; };
 		874A37FA26D11CE200CC8207 /* Scrumdinger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Scrumdinger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumdingerApp.swift; sourceTree = "<group>"; };
 		874A37FF26D11CE200CC8207 /* MeetingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingView.swift; sourceTree = "<group>"; };
@@ -71,6 +73,7 @@
 				874A382226EFABF100CC8207 /* EditView.swift */,
 				873C054C27A5876300657BFC /* MeetingHeaderView.swift */,
 				874A37FF26D11CE200CC8207 /* MeetingView.swift */,
+				873C054E27A59CAE00657BFC /* ScrumProgressViewStyle.swift */,
 				874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */,
 				874A381E26DEED9A00CC8207 /* ScrumsView.swift */,
 				874A380126D11CE400CC8207 /* Assets.xcassets */,
@@ -175,6 +178,7 @@
 				874A382126ECED3900CC8207 /* DetailView.swift in Sources */,
 				874A381126DEA16600CC8207 /* CardView.swift in Sources */,
 				874A381D26DEEB7000CC8207 /* Color+Codable.swift in Sources */,
+				873C054F27A59CAE00657BFC /* ScrumProgressViewStyle.swift in Sources */,
 				874A37FE26D11CE200CC8207 /* ScrumdingerApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		873C054D27A5876300657BFC /* MeetingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873C054C27A5876300657BFC /* MeetingHeaderView.swift */; };
 		873C054F27A59CAE00657BFC /* ScrumProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873C054E27A59CAE00657BFC /* ScrumProgressViewStyle.swift */; };
+		873C055227A59E5300657BFC /* ScrumTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873C055127A59E5300657BFC /* ScrumTimer.swift */; };
 		874A37FE26D11CE200CC8207 /* ScrumdingerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */; };
 		874A380026D11CE200CC8207 /* MeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A37FF26D11CE200CC8207 /* MeetingView.swift */; };
 		874A380226D11CE400CC8207 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 874A380126D11CE400CC8207 /* Assets.xcassets */; };
@@ -24,6 +25,7 @@
 /* Begin PBXFileReference section */
 		873C054C27A5876300657BFC /* MeetingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingHeaderView.swift; sourceTree = "<group>"; };
 		873C054E27A59CAE00657BFC /* ScrumProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumProgressViewStyle.swift; sourceTree = "<group>"; };
+		873C055127A59E5300657BFC /* ScrumTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumTimer.swift; sourceTree = "<group>"; };
 		874A37FA26D11CE200CC8207 /* Scrumdinger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Scrumdinger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumdingerApp.swift; sourceTree = "<group>"; };
 		874A37FF26D11CE200CC8207 /* MeetingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingView.swift; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 			children = (
 				874A381A26DEEB7000CC8207 /* DailyScrum.swift */,
 				874A381B26DEEB7000CC8207 /* Color+Codable.swift */,
+				873C055127A59E5300657BFC /* ScrumTimer.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -176,6 +179,7 @@
 				873C054D27A5876300657BFC /* MeetingHeaderView.swift in Sources */,
 				874A380026D11CE200CC8207 /* MeetingView.swift in Sources */,
 				874A382126ECED3900CC8207 /* DetailView.swift in Sources */,
+				873C055227A59E5300657BFC /* ScrumTimer.swift in Sources */,
 				874A381126DEA16600CC8207 /* CardView.swift in Sources */,
 				874A381D26DEEB7000CC8207 /* Color+Codable.swift in Sources */,
 				873C054F27A59CAE00657BFC /* ScrumProgressViewStyle.swift in Sources */,

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		874A381F26DEED9A00CC8207 /* ScrumsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A381E26DEED9A00CC8207 /* ScrumsView.swift */; };
 		874A382126ECED3900CC8207 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A382026ECED3900CC8207 /* DetailView.swift */; };
 		874A382326EFABF100CC8207 /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A382226EFABF100CC8207 /* EditView.swift */; };
+		87A0515527E103000050261B /* AVPlayer+Ding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A0515427E102FF0050261B /* AVPlayer+Ding.swift */; };
 		87D1530C27C56D8700261C6E /* MeetingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D1530B27C56D8700261C6E /* MeetingFooterView.swift */; };
 /* End PBXBuildFile section */
 
@@ -39,6 +40,7 @@
 		874A381E26DEED9A00CC8207 /* ScrumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumsView.swift; sourceTree = "<group>"; };
 		874A382026ECED3900CC8207 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		874A382226EFABF100CC8207 /* EditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
+		87A0515427E102FF0050261B /* AVPlayer+Ding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "AVPlayer+Ding.swift"; path = "../../../ManagingStateAndLifeCycle/Complete/Scrumdinger/Scrumdinger/Models/AVPlayer+Ding.swift"; sourceTree = "<group>"; };
 		87D1530B27C56D8700261C6E /* MeetingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingFooterView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -100,6 +102,7 @@
 		874A381926DEEB7000CC8207 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				87A0515427E102FF0050261B /* AVPlayer+Ding.swift */,
 				874A381A26DEEB7000CC8207 /* DailyScrum.swift */,
 				874A381B26DEEB7000CC8207 /* Color+Codable.swift */,
 				873C055127A59E5300657BFC /* ScrumTimer.swift */,
@@ -179,6 +182,7 @@
 				874A381C26DEEB7000CC8207 /* DailyScrum.swift in Sources */,
 				874A381F26DEED9A00CC8207 /* ScrumsView.swift in Sources */,
 				874A382326EFABF100CC8207 /* EditView.swift in Sources */,
+				87A0515527E103000050261B /* AVPlayer+Ding.swift in Sources */,
 				873C054D27A5876300657BFC /* MeetingHeaderView.swift in Sources */,
 				874A380026D11CE200CC8207 /* MeetingView.swift in Sources */,
 				87D1530C27C56D8700261C6E /* MeetingFooterView.swift in Sources */,

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		873C054D27A5876300657BFC /* MeetingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873C054C27A5876300657BFC /* MeetingHeaderView.swift */; };
 		874A37FE26D11CE200CC8207 /* ScrumdingerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */; };
 		874A380026D11CE200CC8207 /* MeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A37FF26D11CE200CC8207 /* MeetingView.swift */; };
 		874A380226D11CE400CC8207 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 874A380126D11CE400CC8207 /* Assets.xcassets */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		873C054C27A5876300657BFC /* MeetingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingHeaderView.swift; sourceTree = "<group>"; };
 		874A37FA26D11CE200CC8207 /* Scrumdinger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Scrumdinger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumdingerApp.swift; sourceTree = "<group>"; };
 		874A37FF26D11CE200CC8207 /* MeetingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingView.swift; sourceTree = "<group>"; };
@@ -64,12 +66,13 @@
 		874A37FC26D11CE200CC8207 /* Scrumdinger */ = {
 			isa = PBXGroup;
 			children = (
-				874A382226EFABF100CC8207 /* EditView.swift */,
-				874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */,
-				874A37FF26D11CE200CC8207 /* MeetingView.swift */,
-				874A381E26DEED9A00CC8207 /* ScrumsView.swift */,
-				874A382026ECED3900CC8207 /* DetailView.swift */,
 				874A381026DEA16600CC8207 /* CardView.swift */,
+				874A382026ECED3900CC8207 /* DetailView.swift */,
+				874A382226EFABF100CC8207 /* EditView.swift */,
+				873C054C27A5876300657BFC /* MeetingHeaderView.swift */,
+				874A37FF26D11CE200CC8207 /* MeetingView.swift */,
+				874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */,
+				874A381E26DEED9A00CC8207 /* ScrumsView.swift */,
 				874A380126D11CE400CC8207 /* Assets.xcassets */,
 				874A381926DEEB7000CC8207 /* Models */,
 				874A380626D11CE400CC8207 /* Info.plist */,
@@ -167,6 +170,7 @@
 				874A381C26DEEB7000CC8207 /* DailyScrum.swift in Sources */,
 				874A381F26DEED9A00CC8207 /* ScrumsView.swift in Sources */,
 				874A382326EFABF100CC8207 /* EditView.swift in Sources */,
+				873C054D27A5876300657BFC /* MeetingHeaderView.swift in Sources */,
 				874A380026D11CE200CC8207 /* MeetingView.swift in Sources */,
 				874A382126ECED3900CC8207 /* DetailView.swift in Sources */,
 				874A381126DEA16600CC8207 /* CardView.swift in Sources */,

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		874A381F26DEED9A00CC8207 /* ScrumsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A381E26DEED9A00CC8207 /* ScrumsView.swift */; };
 		874A382126ECED3900CC8207 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A382026ECED3900CC8207 /* DetailView.swift */; };
 		874A382326EFABF100CC8207 /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A382226EFABF100CC8207 /* EditView.swift */; };
+		87D1530C27C56D8700261C6E /* MeetingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D1530B27C56D8700261C6E /* MeetingFooterView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		874A381E26DEED9A00CC8207 /* ScrumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumsView.swift; sourceTree = "<group>"; };
 		874A382026ECED3900CC8207 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		874A382226EFABF100CC8207 /* EditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
+		87D1530B27C56D8700261C6E /* MeetingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingFooterView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +77,7 @@
 				874A382226EFABF100CC8207 /* EditView.swift */,
 				873C054C27A5876300657BFC /* MeetingHeaderView.swift */,
 				874A37FF26D11CE200CC8207 /* MeetingView.swift */,
+				87D1530B27C56D8700261C6E /* MeetingFooterView.swift */,
 				873C054E27A59CAE00657BFC /* ScrumProgressViewStyle.swift */,
 				874A37FD26D11CE200CC8207 /* ScrumdingerApp.swift */,
 				874A381E26DEED9A00CC8207 /* ScrumsView.swift */,
@@ -178,6 +181,7 @@
 				874A382326EFABF100CC8207 /* EditView.swift in Sources */,
 				873C054D27A5876300657BFC /* MeetingHeaderView.swift in Sources */,
 				874A380026D11CE200CC8207 /* MeetingView.swift in Sources */,
+				87D1530C27C56D8700261C6E /* MeetingFooterView.swift in Sources */,
 				874A382126ECED3900CC8207 /* DetailView.swift in Sources */,
 				873C055227A59E5300657BFC /* ScrumTimer.swift in Sources */,
 				874A381126DEA16600CC8207 /* CardView.swift in Sources */,

--- a/Scrumdinger/DetailView.swift
+++ b/Scrumdinger/DetailView.swift
@@ -8,7 +8,7 @@ struct DetailView: View {
         List {
             Section(header: Text("Meeting Info")) {
                 NavigationLink(
-                    destination: MeetingView()) {
+                    destination: MeetingView(scrum: $scrum)) {
                         Label("Start Meeting", systemImage: "timer")
                             .font(.headline)
                             .foregroundColor(.accentColor)

--- a/Scrumdinger/MeetingFooterView.swift
+++ b/Scrumdinger/MeetingFooterView.swift
@@ -1,0 +1,49 @@
+//
+//  MeetingFooterView.swift
+//  Scrumdinger
+//
+//  Created by Alex Billson on 22/02/2022.
+//
+
+import SwiftUI
+
+struct MeetingFooterView: View {
+    let speakers: [ScrumTimer.Speaker]
+    var skipAction: () -> Void
+    private var speakerNumber: Int? {
+        guard let index = speakers.firstIndex(where: { !$0.isCompleted }) else { return nil }
+        return index + 1
+    }
+    private var isLastSpeaker: Bool {
+        return speakers.dropLast().allSatisfy { $0.isCompleted }
+    }
+    private var speakerText: String {
+        guard let speakerNumber = speakerNumber else { return "No more speakers" }
+        return "Speaker \(speakerNumber) of \(speakers.count)"
+    }
+    var body: some View {
+        VStack {
+            HStack {
+                if isLastSpeaker {
+                    Text("Last Speaker")
+                } else {
+                    Text(speakerText)
+                    Spacer()
+                    Button(action: skipAction) {
+                        Image(systemName: "forward.fill")
+                    }
+                    .accessibility(label: Text("Next speaker"))
+                }
+            }
+        }
+        .padding([.bottom, .horizontal])
+    }
+}
+
+struct MeetingFooterView_Previews: PreviewProvider {
+    static var speakers = [ScrumTimer.Speaker(name: "Kim", isCompleted: false), ScrumTimer.Speaker(name: "Bill", isCompleted: false)]
+    static var previews: some View {
+        MeetingFooterView(speakers: speakers, skipAction: {})
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Scrumdinger/MeetingHeaderView.swift
+++ b/Scrumdinger/MeetingHeaderView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MeetingHeaderView : View {
     let secondsElapsed: Int
     let secondsRemaining: Int
+    let scrumColor: Color
     
     private var totalSeconds: Int {
         secondsElapsed + secondsRemaining
@@ -25,6 +26,7 @@ struct MeetingHeaderView : View {
     var body: some View {
         VStack {
             ProgressView(value: progress)
+                .progressViewStyle(ScrumProgressViewStyle(scrumColor: scrumColor))
             HStack {
                 VStack(alignment: .leading) {
                     Text("Seconds Elapsed")
@@ -42,12 +44,13 @@ struct MeetingHeaderView : View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Time Remaining"))
         .accessibilityLabel(Text("\(minutesRemaining) minutes"))
+        .padding([.top, .horizontal])
     }
 }
 
 struct MeetingHeaderView_Previews: PreviewProvider {
     static var previews: some View {
-        MeetingHeaderView(secondsElapsed: 60, secondsRemaining: 180)
+        MeetingHeaderView(secondsElapsed: 60, secondsRemaining: 180, scrumColor: DailyScrum.data[0].color)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/Scrumdinger/MeetingHeaderView.swift
+++ b/Scrumdinger/MeetingHeaderView.swift
@@ -1,0 +1,47 @@
+//
+//  MeetingHeaderView.swift
+//  Scrumdinger
+//
+//  Created by Alex Billson on 29/01/2022.
+//
+
+import SwiftUI
+
+struct MeetingHeaderView : View {
+    let secondsElapsed: Int
+    let secondsRemaining: Int
+    
+    private var totalSeconds: Int {
+        secondsElapsed + secondsRemaining
+    }
+    
+    var body: some View {
+        VStack {
+            ProgressView(value: 5, total: 15)
+            
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("Seconds Elapsed")
+                        .font(.caption)
+                    Label("\(secondsElapsed)", systemImage: "hourglass.bottomhalf.fill")
+                }
+                Spacer()
+                VStack(alignment: .trailing) {
+                    Text("Seconds Remaining")
+                        .font(.caption)
+                    Label("\(secondsRemaining)", systemImage: "hourglass.tophalf.fill")
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Time Remaining"))
+        .accessibilityLabel(Text("10 minutes"))
+    }
+}
+
+struct MeetingHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        MeetingHeaderView(secondsElapsed: 60, secondsRemaining: 180)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Scrumdinger/MeetingHeaderView.swift
+++ b/Scrumdinger/MeetingHeaderView.swift
@@ -14,11 +14,17 @@ struct MeetingHeaderView : View {
     private var totalSeconds: Int {
         secondsElapsed + secondsRemaining
     }
+    private var progress: Double {
+        guard totalSeconds > 0 else { return 1 }
+        return Double(secondsElapsed) / Double(totalSeconds)
+    }
+    private var minutesRemaining: Int {
+        secondsRemaining / 60
+    }
     
     var body: some View {
         VStack {
-            ProgressView(value: 5, total: 15)
-            
+            ProgressView(value: progress)
             HStack {
                 VStack(alignment: .leading) {
                     Text("Seconds Elapsed")
@@ -35,7 +41,7 @@ struct MeetingHeaderView : View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Time Remaining"))
-        .accessibilityLabel(Text("10 minutes"))
+        .accessibilityLabel(Text("\(minutesRemaining) minutes"))
     }
 }
 

--- a/Scrumdinger/MeetingView.swift
+++ b/Scrumdinger/MeetingView.swift
@@ -9,23 +9,16 @@ import SwiftUI
 
 struct MeetingView: View {
     @Binding var scrum: DailyScrum
-    @StateObject var scrumtTimer = ScrumTimer()
+    @StateObject var scrumTimer = ScrumTimer()
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 16.0)
                 .fill(scrum.color)
             VStack{
-                MeetingHeaderView(secondsElapsed: scrumtTimer.secondsElapsed, secondsRemaining: scrumtTimer.secondsRemaining, scrumColor: scrum.color)
+                MeetingHeaderView(secondsElapsed: scrumTimer.secondsElapsed, secondsRemaining: scrumTimer.secondsRemaining, scrumColor: scrum.color)
                 Circle()
                     .strokeBorder(lineWidth: 24, antialiased: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
-                HStack{
-                    Text("Speaker 1 of 3")
-                    Spacer()
-                    Button(action: {}) {
-                        Image(systemName: "forward.fill")
-                    }
-                    .accessibilityLabel(Text("Next Speaker"))
-                }
+                MeetingFooterView(speakers: scrumTimer.speakers, skipAction: scrumTimer.skipSpeaker)
             }
         }
         .padding()

--- a/Scrumdinger/MeetingView.swift
+++ b/Scrumdinger/MeetingView.swift
@@ -8,42 +8,33 @@
 import SwiftUI
 
 struct MeetingView: View {
+    @Binding var scrum: DailyScrum
     var body: some View {
-        VStack{
-            ProgressView(value: 5, total: 15)
-            HStack {
-                VStack(alignment: .leading) {
-                    Text("Seconds Elapsed")
-                        .font(.caption)
-                    Label("300", systemImage: "hourglass.bottomhalf.fill")
+        ZStack {
+            RoundedRectangle(cornerRadius: 16.0)
+                .fill(scrum.color)
+            VStack{
+                
+                Circle()
+                    .strokeBorder(lineWidth: 24, antialiased: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
+                HStack{
+                    Text("Speaker 1 of 3")
+                    Spacer()
+                    Button(action: {}) {
+                        Image(systemName: "forward.fill")
+                    }
+                    .accessibilityLabel(Text("Next Speaker"))
                 }
-                Spacer()
-                VStack(alignment: .trailing) {
-                    Text("Seconds Remaining")
-                        .font(.caption)
-                    Label("600", systemImage: "hourglass.tophalf.fill")
-                }
-            }
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text("Time Remaining"))
-            .accessibilityLabel(Text("10 minutes"))
-            Circle()
-                .strokeBorder(lineWidth: 24, antialiased: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
-            HStack{
-                Text("Speaker 1 of 3")
-                Spacer()
-                Button(action: {}) {
-                    Image(systemName: "forward.fill")
-                }
-                .accessibilityLabel(Text("Next Speaker"))
             }
         }
         .padding()
+        .foregroundColor(scrum.color.accessibleFontColor)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
 struct MeetingView_Previews: PreviewProvider {
     static var previews: some View {
-        MeetingView()
+        MeetingView(scrum: .constant(DailyScrum.data[0]))
     }
 }

--- a/Scrumdinger/MeetingView.swift
+++ b/Scrumdinger/MeetingView.swift
@@ -9,12 +9,13 @@ import SwiftUI
 
 struct MeetingView: View {
     @Binding var scrum: DailyScrum
+    @StateObject var scrumtTimer = ScrumTimer()
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 16.0)
                 .fill(scrum.color)
             VStack{
-                
+                MeetingHeaderView(secondsElapsed: scrumtTimer.secondsElapsed, secondsRemaining: scrumtTimer.secondsRemaining, scrumColor: scrum.color)
                 Circle()
                     .strokeBorder(lineWidth: 24, antialiased: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
                 HStack{

--- a/Scrumdinger/MeetingView.swift
+++ b/Scrumdinger/MeetingView.swift
@@ -6,10 +6,14 @@
 //
 
 import SwiftUI
+import AVFoundation
 
 struct MeetingView: View {
     @Binding var scrum: DailyScrum
     @StateObject var scrumTimer = ScrumTimer()
+    
+    private var player: AVPlayer { AVPlayer.sharedDingPlayer }
+    
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 16.0)
@@ -17,12 +21,23 @@ struct MeetingView: View {
             VStack{
                 MeetingHeaderView(secondsElapsed: scrumTimer.secondsElapsed, secondsRemaining: scrumTimer.secondsRemaining, scrumColor: scrum.color)
                 Circle()
-                    .strokeBorder(lineWidth: 24, antialiased: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
+                    .strokeBorder(lineWidth: 24, antialiased: true)
                 MeetingFooterView(speakers: scrumTimer.speakers, skipAction: scrumTimer.skipSpeaker)
             }
         }
         .padding()
         .foregroundColor(scrum.color.accessibleFontColor)
+        .onAppear {
+            scrumTimer.reset(lengthInMinutes: scrum.lengthInMinutes, attendees: scrum.attendees)
+            scrumTimer.speakerChangedAction = {
+                player.seek(to: .zero)
+                player.play()
+            }
+            scrumTimer.startScrum()
+        }
+        .onDisappear {
+            scrumTimer.stopScrum()
+        }
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Scrumdinger/Models/DailyScrum.swift
+++ b/Scrumdinger/Models/DailyScrum.swift
@@ -13,7 +13,7 @@ struct DailyScrum: Identifiable {
     var attendees: [String]
     var lengthInMinutes: Int
     var color: Color
-    
+
     init(id: UUID = UUID(), title: String, attendees: [String], lengthInMinutes: Int, color: Color) {
         self.id = id
         self.title = title
@@ -40,14 +40,15 @@ extension DailyScrum {
         var lengthInMinutes: Double = 5.0
         var color: Color = .random
     }
-    
+
     var data: Data {
         return Data(title: title, attendees: attendees, lengthInMinutes: Double(lengthInMinutes), color: color)
-            }
-            mutating func update(from data: Data) {
-                title = data.title
-                attendees = data.attendees
-                lengthInMinutes = Int(data.lengthInMinutes)
-                color = data.color
+    }
+
+    mutating func update(from data: Data) {
+        title = data.title
+        attendees = data.attendees
+        lengthInMinutes = Int(data.lengthInMinutes)
+        color = data.color
     }
 }

--- a/Scrumdinger/Models/ScrumTimer.swift
+++ b/Scrumdinger/Models/ScrumTimer.swift
@@ -1,0 +1,136 @@
+//
+//  ScrumTimer.swift
+//  Scrumdinger
+//
+//  Created by Alex Billson on 29/01/2022.
+//
+
+import Foundation
+
+
+/// Keeps time for a daily scrum meeting. Keep track of the total meeting time, the time for each speaker, and the name of the current speaker.
+class ScrumTimer: ObservableObject {
+    /// A struct to keep track of meeting attendees during a meeting.
+    struct Speaker: Identifiable {
+        /// The attendee name.
+        let name: String
+        /// True if the attendee has completed their turn to speak.
+        var isCompleted: Bool
+        /// Id for Identifiable conformance.
+        let id = UUID()
+    }
+    /// The name of the meeting attendee who is speaking.
+    @Published var activeSpeaker = ""
+    /// The number of seconds since the beginning of the meeting.
+    @Published var secondsElapsed = 0
+    /// The number of seconds until all attendees have had a turn to speak.
+    @Published var secondsRemaining = 0
+    /// All meeting attendees, listed in the order they will speak.
+    var speakers: [Speaker] = []
+
+    /// The scrum meeting length.
+    var lengthInMinutes: Int
+    /// A closure that is executed when a new attendee begins speaking.
+    var speakerChangedAction: (() -> Void)?
+
+    private var timer: Timer?
+    private var timerStopped = false
+    private var frequency: TimeInterval { 1.0 / 60.0 }
+    private var lengthInSeconds: Int { lengthInMinutes * 60 }
+    private var secondsPerSpeaker: Int {
+        (lengthInMinutes * 60) / speakers.count
+    }
+    private var secondsElapsedForSpeaker: Int = 0
+    private var speakerIndex: Int = 0
+    private var speakerText: String {
+        return "Speaker \(speakerIndex + 1): " + speakers[speakerIndex].name
+    }
+    private var startDate: Date?
+    
+    /**
+     Initialize a new timer. Initializing a time with no arguments creates a ScrumTimer with no attendees and zero length.
+     Use `startScrum()` to start the timer.
+     
+     - Parameters:
+        - lengthInMinutes: The meeting length.
+        -  attendees: The name of each attendee.
+     */
+    init(lengthInMinutes: Int = 0, attendees: [String] = []) {
+        self.lengthInMinutes = lengthInMinutes
+        self.speakers = attendees.isEmpty ? [Speaker(name: "Player 1", isCompleted: false)] : attendees.map { Speaker(name: $0, isCompleted: false) }
+        secondsRemaining = lengthInSeconds
+        activeSpeaker = speakerText
+    }
+    /// Start the timer.
+    func startScrum() {
+        changeToSpeaker(at: 0)
+    }
+    /// Stop the timer.
+    func stopScrum() {
+        timer?.invalidate()
+        timer = nil
+        timerStopped = true
+    }
+    /// Advance the timer to the next speaker.
+    func skipSpeaker() {
+        changeToSpeaker(at: speakerIndex + 1)
+    }
+
+    private func changeToSpeaker(at index: Int) {
+        if index > 0 {
+            let previousSpeakerIndex = index - 1
+            speakers[previousSpeakerIndex].isCompleted = true
+        }
+        secondsElapsedForSpeaker = 0
+        guard index < speakers.count else { return }
+        speakerIndex = index
+        activeSpeaker = speakerText
+
+        secondsElapsed = index * secondsPerSpeaker
+        secondsRemaining = lengthInSeconds - secondsElapsed
+        startDate = Date()
+        timer = Timer.scheduledTimer(withTimeInterval: frequency, repeats: true) { [weak self] timer in
+            if let self = self, let startDate = self.startDate {
+                let secondsElapsed = Date().timeIntervalSince1970 - startDate.timeIntervalSince1970
+                self.update(secondsElapsed: Int(secondsElapsed))
+            }
+        }
+    }
+
+    private func update(secondsElapsed: Int) {
+        secondsElapsedForSpeaker = secondsElapsed
+        self.secondsElapsed = secondsPerSpeaker * speakerIndex + secondsElapsedForSpeaker
+        guard secondsElapsed <= secondsPerSpeaker else {
+            return
+        }
+        secondsRemaining = max(lengthInSeconds - self.secondsElapsed, 0)
+
+        guard !timerStopped else { return }
+
+        if secondsElapsedForSpeaker >= secondsPerSpeaker {
+            changeToSpeaker(at: speakerIndex + 1)
+            speakerChangedAction?()
+        }
+    }
+    
+    /**
+     Reset the timer with a new meeting length and new attendees.
+     
+     - Parameters:
+         - lengthInMinutes: The meeting length.
+         - attendees: The name of each attendee.
+     */
+    func reset(lengthInMinutes: Int, attendees: [String]) {
+        self.lengthInMinutes = lengthInMinutes
+        self.speakers = attendees.isEmpty ? [Speaker(name: "Player 1", isCompleted: false)] : attendees.map { Speaker(name: $0, isCompleted: false) }
+        secondsRemaining = lengthInSeconds
+        activeSpeaker = speakerText
+    }
+}
+
+extension DailyScrum {
+    /// A new `ScrumTimer` using the meeting length and attendees in the `DailyScrum`.
+    var timer: ScrumTimer {
+        ScrumTimer(lengthInMinutes: lengthInMinutes, attendees: attendees)
+    }
+}

--- a/Scrumdinger/ScrumProgressViewStyle.swift
+++ b/Scrumdinger/ScrumProgressViewStyle.swift
@@ -1,0 +1,23 @@
+//
+//  ScrumProgressViewStyle.swift
+//  Scrumdinger
+//
+//  Created by Alex Billson on 29/01/2022.
+//
+
+import SwiftUI
+
+struct ScrumProgressViewStyle: ProgressViewStyle {
+    var scrumColor: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10.0)
+                .fill(scrumColor.accessibleFontColor)
+                .frame(height: 20.0)
+            ProgressView(configuration)
+                .frame(height: 12.0)
+                .padding(.horizontal)
+        }
+    }
+}

--- a/Scrumdinger/ScrumsView.swift
+++ b/Scrumdinger/ScrumsView.swift
@@ -40,7 +40,3 @@ struct ScrumsView_Previews: PreviewProvider {
         }
     }
 }
-
-
-// Managing State and Life Cycle - tutorial
-// https://developer.apple.com/tutorials/app-dev-training/managing-state-and-life-cycle

--- a/Scrumdinger/ScrumsView.swift
+++ b/Scrumdinger/ScrumsView.swift
@@ -40,3 +40,7 @@ struct ScrumsView_Previews: PreviewProvider {
         }
     }
 }
+
+
+// Managing State and Life Cycle - tutorial
+// https://developer.apple.com/tutorials/app-dev-training/managing-state-and-life-cycle


### PR DESCRIPTION
### Create an Overlay View
Start by adding some visual polish to the meeting timer screen. You’ll use a ZStack to draw a simple shape behind the meeting view. To maintain visual consistency with the list view, you’ll fill the shape with the scrum’s color.

### Extract the Meeting Header
SwiftUI supports composing large views from smaller views. You can more easily maintain your code if you keep your views focused.
In this section, you’ll extract the meeting header into its own view, create properties to pass a meeting’s elapsed and remaining time, and update the logic of the progress view and accessibility labels.

### Add Design Elements to the Meeting Header
The view now uses dynamic properties, but the UI needs a few design adjustments to approach the final design.

### Add a State Object for a Source of Truth
You’ve used @State to create a source of truth for value type models. You can use @StateObject to create a source of truth for reference type models that conform to the ObservableObject protocol.
The starter project includes the ScrumTimer class, a model which conforms to ObservableObject. You’ll use @StateObject to declare an instance of this class in the meeting view.

### Add Life Cycle Events
SwiftUI provides life cycle methods to trigger events when a view appears and disappears. For example, you could add onAppear(perform:) to start an animation after a view appears. And you could add onDisappear(perform:) to release unnecessary resources when a view disappears.
In this section, you’ll add calls from the ScrumTimer class to reset, start, and stop the timer at specific times in the view’s life cycle.

### Extract the Meeting Footer
In this section, you’ll extract the meeting footer into a subview of MeetingTimer and add logic that determines the speaker number and name. You’ll then add calls from the ScrumTimer class that advance the timer to the next speaker.

### Trigger Sound with AVFoundation
With the AVFoundation framework, you can work with audiovisual media on Apple platforms. You’ll use AVFoundation to trigger audio feedback when a speaker’s time has ended.